### PR TITLE
Modified fields search

### DIFF
--- a/Model/Tagged.php
+++ b/Model/Tagged.php
@@ -167,7 +167,11 @@ class Tagged extends TagsAppModel {
 					$query['fields'] = "COUNT(DISTINCT $Model->alias.$Model->primaryKey)";
 					$this->Behaviors->Containable->setup($this, array('autoFields' => false));
 				} else {
-					array_unshift($query['fields'], "DISTINCT " . join(',', $this->getDataSource()->fields($Model)));
+					if ($query['fields'] == null) {
+						$query['fields'][] = "DISTINCT " . join(',', $this->getDataSource()->fields($Model));
+					} else {
+						array_unshift($query['fields'], "DISTINCT " . join(',', $this->getDataSource()->fields($Model)));
+					}
 				}
 
 				if (!empty($query['by'])) {


### PR DESCRIPTION
If fields are being passed, adding the 'DISTINCT' option at the end of the fields query causes mysql errors - Pushing the fields to the top of the stack prevents the error
