### PR TITLE
Updated query for distinct if Fields are passed

### DIFF
--- a/Model/Tagged.php
+++ b/Model/Tagged.php
@@ -167,7 +167,11 @@ class Tagged extends TagsAppModel {
 					$query['fields'] = "COUNT(DISTINCT $Model->alias.$Model->primaryKey)";
 					$this->Behaviors->Containable->setup($this, array('autoFields' => false));
 				} else {
-					$query['fields'][] = "DISTINCT " . join(',', $this->getDataSource()->fields($Model));
+				  	if ($query['fields'] == null) {
+				    		$query['fields'][] = "DISTINCT " . join(',', $this->getDataSource()->fields($Model));
+			  		} else {
+				    		array_unshift($query['fields'], "DISTINCT " . join(',', $this->getDataSource()->fields($Model)));
+					}
 				}
 
 				if (!empty($query['by'])) {


### PR DESCRIPTION
The logic previously in place prevented fields from being passed and thus failing on custom pagination and fields query.
