### PR TITLE
Change deprecated SessionComponent::setFlash() to FlashComponent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - 7.0
   - 7.1
 
@@ -25,6 +26,9 @@ matrix:
       env:
         - CAKE_VERSION=2.9
     - php: 5.5
+      env:
+        - CAKE_VERSION=2.9
+    - php: 5.6
       env:
         - CAKE_VERSION=2.9
     - php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 7.0
+  - 7.1
 
 env:
   global:
@@ -12,28 +14,25 @@ env:
     - REQUIRE="phpunit/phpunit:3.7.31"
 
   matrix:
-    - DB=mysql CAKE_VERSION=2.7
+    - DB=mysql CAKE_VERSION=2.9
 
 matrix:
   include:
     - php: 5.3
       env:
-        - CAKE_VERSION=2.7
+        - CAKE_VERSION=2.9
     - php: 5.4
       env:
-        - CAKE_VERSION=2.7
+        - CAKE_VERSION=2.9
     - php: 5.5
       env:
-        - CAKE_VERSION=2.7
-    - php: 5.3
+        - CAKE_VERSION=2.9
+    - php: 7.0
       env:
-        - CAKE_VERSION=2.6
-    - php: 5.4
+        - CAKE_VERSION=2.9
+    - php: 7.1
       env:
-        - CAKE_VERSION=2.6
-    - php: 5.5
-      env:
-        - CAKE_VERSION=2.6
+        - CAKE_VERSION=2.9
 
 before_script:
   - git clone https://github.com/steinkel/travis.git --depth 1 ../travis

--- a/Controller/TagsController.php
+++ b/Controller/TagsController.php
@@ -33,7 +33,7 @@ class TagsController extends TagsAppController {
  * @var array
  */
 	public $components = array(
-		'Session',
+		'Flash',
 		'Paginator'
 	);
 

--- a/Controller/TagsController.php
+++ b/Controller/TagsController.php
@@ -66,7 +66,7 @@ class TagsController extends TagsAppController {
 		try {
 			$this->set('tag', $this->{$this->modelClass}->view($keyName));
 		} catch (Exception $e) {
-			$this->Session->setFlash($e->getMessage());
+			$this->Flash->warning($e->getMessage());
 			$this->redirect('/');
 		}
 	}
@@ -91,7 +91,7 @@ class TagsController extends TagsAppController {
 		try {
 			$this->set('tag', $this->{$this->modelClass}->view($keyName));
 		} catch (Exception $e) {
-			$this->Session->setFlash($e->getMessage());
+			$this->Flash->warning($e->getMessage());
 			$this->redirect('/');
 		}
 	}
@@ -104,7 +104,7 @@ class TagsController extends TagsAppController {
 	public function admin_add() {
 		if (!empty($this->request->data)) {
 			if ($this->{$this->modelClass}->add($this->request->data)) {
-				$this->Session->setFlash(__d('tags', 'The Tags has been saved.'));
+				$this->Flash->success(__d('tags', 'The Tags has been saved.'));
 				$this->redirect(array('action' => 'index'));
 			}
 		}
@@ -120,13 +120,13 @@ class TagsController extends TagsAppController {
 		try {
 			$result = $this->{$this->modelClass}->edit($tagId, $this->request->data);
 			if ($result === true) {
-				$this->Session->setFlash(__d('tags', 'Tag saved.'));
+				$this->Flash->success(__d('tags', 'Tag saved.'));
 				$this->redirect(array('action' => 'index'));
 			} else {
 				$this->request->data = $result;
 			}
 		} catch (Exception $e) {
-			$this->Session->setFlash($e->getMessage());
+			$this->Flash->warning($e->getMessage());
 			$this->redirect(array('action' => 'index'));
 		}
 
@@ -143,9 +143,9 @@ class TagsController extends TagsAppController {
  */
 	public function admin_delete($tagId = null) {
 		if ($this->{$this->modelClass}->delete($tagId)) {
-			$this->Session->setFlash(__d('tags', 'Tag deleted.'));
+			$this->Flash->success(__d('tags', 'Tag deleted.'));
 		} else {
-			$this->Session->setFlash(__d('tags', 'Invalid Tag.'));
+			$this->Flash->warning(__d('tags', 'Invalid Tag.'));
 		}
 		$this->redirect(array('action' => 'index'));
 	}

--- a/Test/Case/Controller/TagsControllerTest.php
+++ b/Test/Case/Controller/TagsControllerTest.php
@@ -97,7 +97,7 @@ class TagsControllerTest extends CakeTestCase {
 			'url' => array()
 		);
 		$this->Tags->constructClasses();
-		$this->Tags->Session = $this->getMock('SessionComponent', array(), array(), '', false);
+		$this->Tags->Flash = $this->getMock('FlashComponent', array(), array(), '', false);
 	}
 
 /**
@@ -173,13 +173,13 @@ class TagsControllerTest extends CakeTestCase {
  * @return void
  */
 	public function testAdminDelete() {
-		$this->Tags->Session->expects($this->at(0))
-			->method('setFlash')
+		$this->Tags->Flash->expects($this->at(0))
+			->method('warning')
 			->with($this->equalTo(__d('tags', 'Invalid Tag.')))
 			->will($this->returnValue(true));
 
-		$this->Tags->Session->expects($this->at(1))
-			->method('setFlash')
+		$this->Tags->Flash->expects($this->at(1))
+			->method('success')
 			->with($this->equalTo(__d('tags', 'Tag deleted.')))
 			->will($this->returnValue(true));
 


### PR DESCRIPTION
SessionComponent::setFlash() is deprecated since version 2.7.0. We should use Flash to create flash messages.

I have replaced all $this->Flash->set() calls to one of:
$this->Flash->success()
$this->Flash->warning()
depending on the context they are called on (operation done or exception).

I also updated the tests.

References:
https://book.cakephp.org/2.0/en/core-libraries/components/sessions.html#creating-notification-messages
https://book.cakephp.org/2.0/en/appendices/2-7-migration-guide.html#controller
