### PR TITLE
Change deprecated SessionComponent::setFlash() to FlashComponent on branch 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ php:
 env:
   global:
     - PLUGIN_NAME=Tags
-    - DB=mysql
-    - REQUIRE="phpunit/phpunit:3.7.31"
+    - REQUIRE=""
+    - DB=mysql CAKE_VERSION=master
+
 
   matrix:
     - DB=mysql CAKE_VERSION=master
@@ -27,7 +28,6 @@ matrix:
         - CAKE_VERSION=master
 
 before_script:
-  - git clone https://github.com/burzum/travis.git --depth 1 ../travis
   - ../travis/before_script.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
-  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
 
 env:
   global:
@@ -16,13 +16,13 @@ env:
 
 matrix:
   include:
-    - php: 5.3
+    - php: 5.6
       env:
         - CAKE_VERSION=master
-    - php: 5.4
+    - php: 7.0
       env:
         - CAKE_VERSION=master
-    - php: 5.5
+    - php: 7.1
       env:
         - CAKE_VERSION=master
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,33 +2,23 @@ language: php
 
 php:
   - 5.6
-  - 7.0
-  - 7.1
 
 env:
   global:
     - PLUGIN_NAME=Tags
-    - REQUIRE="phpunit/phpunit:6.3.0"
-    - DB=mysql CAKE_VERSION=master
-
+    - REQUIRE=""
+    - DB=mysql CAKE_VERSION=3.4
 
   matrix:
-    - DB=mysql CAKE_VERSION=master
+    - DB=mysql CAKE_VERSION=3.4
 
 matrix:
   include:
     - php: 5.6
       env:
-        - CAKE_VERSION=master
-    - php: 7.0
-      env:
-        - CAKE_VERSION=master
-    - php: 7.1
-      env:
-        - CAKE_VERSION=master
+        - PHPCS=1
 
 before_script:
-  - cp -R tags ../tags && cd ../tags
   - ../travis/before_script.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
 env:
   global:
     - PLUGIN_NAME=Tags
-    - REQUIRE=""
+    - REQUIRE="phpunit/phpunit:6.3.0"
     - DB=mysql CAKE_VERSION=master
 
 
@@ -28,6 +28,7 @@ matrix:
         - CAKE_VERSION=master
 
 before_script:
+  - cp -R tags ../tags && cd ../tags
   - ../travis/before_script.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,30 +2,47 @@ language: php
 
 php:
   - 5.6
+  - 7.0
+  - 7.1
+
+sudo: false
 
 env:
-  global:
-    - PLUGIN_NAME=Tags
-    - REQUIRE=""
-    - DB=mysql CAKE_VERSION=3.4
-
   matrix:
-    - DB=mysql CAKE_VERSION=3.4
+    - DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
+    - DB=pgsql db_dsn='postgres://postgres@127.0.0.1/cakephp_test'
+    - DB=sqlite db_dsn='sqlite:///:memory:'
+
+  global:
+    - DEFAULT=1
 
 matrix:
+  fast_finish: true
+
   include:
     - php: 5.6
-      env:
-        - PHPCS=1
+      env: PHPCS=1 DEFAULT=0
+
+    - php: 5.6
+      env: COVERALLS=1 DEFAULT=0 DB=mysql db_dsn='mysql://travis@0.0.0.0/cakephp_test'
 
 before_script:
-  - ../travis/before_script.sh
+  - composer self-update
+  - composer install --prefer-dist --no-interaction
+
+  - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'CREATE DATABASE cakephp_test; GRANT ALL PRIVILEGES ON cakephp_test.* TO travis@localhost;'; fi"
+  - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'CREATE DATABASE cakephp_test;' -U postgres; fi"
+
+  - sh -c "if [ '$PHPCS' = '1' ]; then composer require 'cakephp/cakephp-codesniffer:@stable'; fi"
+
+  - sh -c "if [ '$COVERALLS' = '1' ]; then composer require --dev 'satooshi/php-coveralls:@stable'; fi"
+  - sh -c "if [ '$COVERALLS' = '1' ]; then mkdir -p build/logs; fi"
 
 script:
-  - ../travis/script.sh
-
-after_success:
-  - ../travis/after_success.sh
+  - sh -c "if [ '$DEFAULT' = '1' ]; then ./vendor/bin/phpunit --stderr; fi"
+  - sh -c "if [ '$PHPCS' = '1' ]; then ./vendor/bin/phpcs -p -n --extensions=php --standard=vendor/cakephp/cakephp-codesniffer/CakePHP ./src ./tests; fi"
+  - sh -c "if [ '$COVERALLS' = '1' ]; then ./vendor/bin/phpunit --stderr --coverage-clover build/logs/clover.xml; fi"
+  - sh -c "if [ '$COVERALLS' = '1' ]; then php vendor/bin/coveralls -c .coveralls.yml -v; fi"
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,11 +29,6 @@ matrix:
 before_script:
   - git clone https://github.com/burzum/travis.git --depth 1 ../travis
   - ../travis/before_script.sh
-  - if [ "$PHPCS" != 1 ]; then
-            echo "
-                require_once APP . DS . 'vendor' . DS . 'phpunit' . DS . 'phpunit' . DS . 'PHPUnit' . DS . 'Autoload.php';
-            " >> ../cakephp/app/Config/bootstrap.php;
-    fi
 
 script:
   - ../travis/script.sh

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ It saves all tags in a single tags table and connects any kind of records to the
 Requirements
 ------------
 
-* CakePHP 2.5+
-* PHP 5.2.8+
+* CakePHP 3.4+
+* PHP 5.6+
 
 Documentation
 -------------

--- a/Test/Case/AllTagsTest.php
+++ b/Test/Case/AllTagsTest.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * All Tags plugin tests
+ */
+class AllTagsTest extends CakeTestCase {
+
+/**
+ * Suite define the tests for this plugin
+ *
+ * @return void
+ */
+	public static function suite() {
+		$suite = new CakeTestSuite('All Tags test');
+
+		$path = CakePlugin::path('Tags') . 'Test' . DS . 'Case' . DS;
+		$suite->addTestDirectoryRecursive($path);
+
+		return $suite;
+	}
+
+}

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 	"require": {
 		"php": ">=5.6",
 		"cakephp/plugin-installer": "*",
-		"cakephp/cakephp": "~3.2"
+		"cakephp/cakephp": "~3.4"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "*"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.4",
+		"php": ">=5.6",
 		"cakephp/plugin-installer": "*",
 		"cakephp/cakephp": "~3.2"
 	},

--- a/src/Controller/TagsController.php
+++ b/src/Controller/TagsController.php
@@ -35,7 +35,7 @@ class TagsController extends TagsAppController
  * @var array
  */
     public $components = array(
-        'Session',
+        'Flash',
         'Paginator'
     );
 
@@ -70,7 +70,7 @@ class TagsController extends TagsAppController
         try {
             $this->set('tag', $this->{$this->modelClass}->view($id));
         } catch (Exception $e) {
-            $this->Session->setFlash($e->getMessage());
+            $this->Flash->warning($e->getMessage());
             $this->redirect('/');
         }
     }
@@ -97,7 +97,7 @@ class TagsController extends TagsAppController
         try {
             $this->set('tag', $this->{$this->modelClass}->view($id));
         } catch (Exception $e) {
-            $this->Session->setFlash($e->getMessage());
+            $this->Flash->warning($e->getMessage());
             $this->redirect('/');
         }
     }
@@ -111,7 +111,7 @@ class TagsController extends TagsAppController
     {
         if (!empty($this->request->data)) {
             if ($this->{$this->modelClass}->add($this->request->data)) {
-                $this->Session->setFlash(__d('tags', 'The Tags has been saved.'));
+                $this->Flash->success(__d('tags', 'The Tags has been saved.'));
                 $this->redirect(array('action' => 'index'));
             }
         }
@@ -128,13 +128,13 @@ class TagsController extends TagsAppController
         try {
             $result = $this->{$this->modelClass}->edit($id, $this->request->data);
             if ($result === true) {
-                $this->Session->setFlash(__d('tags', 'Tag saved.'));
+                $this->Flash->success(__d('tags', 'Tag saved.'));
                 $this->redirect(array('action' => 'index'));
             } else {
                 $this->request->data = $result;
             }
         } catch (Exception $e) {
-            $this->Session->setFlash($e->getMessage());
+            $this->Flash->warning($e->getMessage());
             $this->redirect(array('action' => 'index'));
         }
 
@@ -152,9 +152,9 @@ class TagsController extends TagsAppController
     public function admin_delete($id = null)
     {
         if ($this->{$this->modelClass}->delete($id)) {
-            $this->Session->setFlash(__d('tags', 'Tag deleted.'));
+            $this->Flash->success(__d('tags', 'Tag deleted.'));
         } else {
-            $this->Session->setFlash(__d('tags', 'Invalid Tag.'));
+            $this->Flash->warning(__d('tags', 'Invalid Tag.'));
         }
         $this->redirect(array('action' => 'index'));
     }

--- a/tests/TestCase/Controller/TagsControllerTest.php
+++ b/tests/TestCase/Controller/TagsControllerTest.php
@@ -97,7 +97,7 @@ class TagsControllerTest extends TestCase
             'named' => array(),
             'url' => array());
         $this->Tags->constructClasses();
-        $this->Tags->Session = $this->getMock('SessionComponent', array(), array(), '', false);
+        $this->Tags->Flash = $this->getMock('FlashComponent', array(), array(), '', false);
     }
 
 /**
@@ -180,13 +180,13 @@ class TagsControllerTest extends TestCase
  */
     public function testAdminDelete()
     {
-        $this->Tags->Session->expects($this->at(0))
-            ->method('setFlash')
+        $this->Tags->Flash->expects($this->at(0))
+            ->method('warning')
             ->with($this->equalTo(__d('tags', 'Invalid Tag.')))
             ->will($this->returnValue(true));
 
-        $this->Tags->Session->expects($this->at(1))
-            ->method('setFlash')
+        $this->Tags->Flash->expects($this->at(1))
+            ->method('success')
             ->with($this->equalTo(__d('tags', 'Tag deleted.')))
             ->will($this->returnValue(true));
 


### PR DESCRIPTION
SessionComponent::setFlash() is deprecated. You should use Flash instead.

I have replaced all $this->Flash->set() calls to one of:
$this->Flash->success()
$this->Flash->warning()
depending on the context they are called on (operation done or exception).

I also updated the tests.

Reference:
https://book.cakephp.org/3.0/en/appendices/3-0-migration-guide.html#sessioncomponent