### PR TITLE
Change deprecated SessionComponent::setFlash() to FlashComponent

### DIFF
--- a/src/Controller/TagsController.php
+++ b/src/Controller/TagsController.php
@@ -35,7 +35,7 @@ class TagsController extends TagsAppController
  * @var array
  */
     public $components = array(
-        'Session',
+        'Flash',
         'Paginator'
     );
 
@@ -70,7 +70,7 @@ class TagsController extends TagsAppController
         try {
             $this->set('tag', $this->{$this->modelClass}->view($id));
         } catch (Exception $e) {
-            $this->Session->setFlash($e->getMessage());
+            $this->Flash->warning($e->getMessage());
             $this->redirect('/');
         }
     }
@@ -97,7 +97,7 @@ class TagsController extends TagsAppController
         try {
             $this->set('tag', $this->{$this->modelClass}->view($id));
         } catch (Exception $e) {
-            $this->Session->setFlash($e->getMessage());
+            $this->Flash->warning($e->getMessage());
             $this->redirect('/');
         }
     }
@@ -111,7 +111,7 @@ class TagsController extends TagsAppController
     {
         if (!empty($this->request->data)) {
             if ($this->{$this->modelClass}->add($this->request->data)) {
-                $this->Session->setFlash(__d('tags', 'The Tags has been saved.'));
+                $this->Flash->success(__d('tags', 'The Tags has been saved.'));
                 $this->redirect(array('action' => 'index'));
             }
         }
@@ -128,13 +128,13 @@ class TagsController extends TagsAppController
         try {
             $result = $this->{$this->modelClass}->edit($id, $this->request->data);
             if ($result === true) {
-                $this->Session->setFlash(__d('tags', 'Tag saved.'));
+                $this->Flash->success(__d('tags', 'Tag saved.'));
                 $this->redirect(array('action' => 'index'));
             } else {
                 $this->request->data = $result;
             }
         } catch (Exception $e) {
-            $this->Session->setFlash($e->getMessage());
+            $this->Flash->warning($e->getMessage());
             $this->redirect(array('action' => 'index'));
         }
 
@@ -152,9 +152,9 @@ class TagsController extends TagsAppController
     public function admin_delete($id = null)
     {
         if ($this->{$this->modelClass}->delete($id)) {
-            $this->Session->setFlash(__d('tags', 'Tag deleted.'));
+            $this->Flash->success(__d('tags', 'Tag deleted.'));
         } else {
-            $this->Session->setFlash(__d('tags', 'Invalid Tag.'));
+            $this->Flash->warning(__d('tags', 'Invalid Tag.'));
         }
         $this->redirect(array('action' => 'index'));
     }

--- a/tests/TestCase/Controller/TagsControllerTest.php
+++ b/tests/TestCase/Controller/TagsControllerTest.php
@@ -97,7 +97,7 @@ class TagsControllerTest extends TestCase
             'named' => array(),
             'url' => array());
         $this->Tags->constructClasses();
-        $this->Tags->Session = $this->getMock('SessionComponent', array(), array(), '', false);
+        $this->Tags->Flash = $this->getMock('FlashComponent', array(), array(), '', false);
     }
 
 /**
@@ -180,13 +180,13 @@ class TagsControllerTest extends TestCase
  */
     public function testAdminDelete()
     {
-        $this->Tags->Session->expects($this->at(0))
-            ->method('setFlash')
+        $this->Tags->Flash->expects($this->at(0))
+            ->method('warning')
             ->with($this->equalTo(__d('tags', 'Invalid Tag.')))
             ->will($this->returnValue(true));
 
-        $this->Tags->Session->expects($this->at(1))
-            ->method('setFlash')
+        $this->Tags->Flash->expects($this->at(1))
+            ->method('success')
             ->with($this->equalTo(__d('tags', 'Tag deleted.')))
             ->will($this->returnValue(true));
 


### PR DESCRIPTION
SessionComponent::setFlash() is deprecated. You should use Flash instead.

I have replaced all $this->Flash->set() calls to one of:
$this->Flash->success()
$this->Flash->warning()
depending on the context they are called on (operation done or exception).

I also updated the tests.

Reference:
https://book.cakephp.org/3.0/en/appendices/3-0-migration-guide.html#sessioncomponent